### PR TITLE
Build paths in a compatible way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+out/

--- a/src/da65xx.ts
+++ b/src/da65xx.ts
@@ -366,19 +366,19 @@ export class Debug65xxSession extends LoggingDebugSession {
             if(args0.src) {
                 this.src = args0.src;
             } else {
-                this.src = this.cwd + '\\';
+                this.src = this.cwd;
             }
             if (args0.list) {
                 list = args0.list;
             } else {
-                list = this.cwd + '\\';
+                list = this.cwd;
             }
         } else {
             let extension = path.extname(this.program);
             binBase = path.basename(this.program, extension);
-            sbin = this.cwd + '\\' + binBase + '.bin';
-            this.src = this.cwd + '\\';
-            list = this.cwd + '\\';
+            sbin = path.join(this.cwd, binBase + '.bin');
+            this.src = this.cwd;
+            list = this.cwd;
         }
 
         // prepare source map
@@ -482,7 +482,7 @@ export class Debug65xxSession extends LoggingDebugSession {
         response.body = {
             stackFrames: stk.frames.map((f, ix) => {
                 // fix up source file path
-                const sf: DebugProtocol.StackFrame = new StackFrame(f.index, f.name, this.createSource(this.src + f.file), this.convertDebuggerLineToClient(f.line));
+                const sf: DebugProtocol.StackFrame = new StackFrame(f.index, f.name, this.createSource(path.join(this.src, f.file)), this.convertDebuggerLineToClient(f.line));
                 sf.moduleId = f.file;
                 if (typeof f.column === 'number') {
                     sf.column = this.convertDebuggerColumnToClient(f.column);
@@ -1148,7 +1148,7 @@ export class Debug65xxSession extends LoggingDebugSession {
         let sources: DebugProtocol.Source[] = [];
 
         for( let module of this.sourceMap.getModules()) {
-            sources.push(this.createSource(this.src + module + '.s'));
+            sources.push(this.createSource(path.join(this.src, module + '.s')));
         }
 
         response.body = {

--- a/src/sourcemap.ts
+++ b/src/sourcemap.ts
@@ -103,7 +103,7 @@ export class SourceMap {
     public constructor(dir: string, basename: string) {
         this.basename = basename;
 
-        this.createSymbolMap(dir + basename + '.sym');
+        this.createSymbolMap(path.join(dir, basename + '.sym'));
         this.createSourceMap(dir, basename);
         this.createReverseMap();
     }
@@ -249,7 +249,7 @@ export class SourceMap {
     }
 
     private createSourceMap(dir: string, basename: string) {
-        this.parse_map(dir + basename + '.map');
+        this.parse_map(path.join(dir, basename + '.map'));
 
         // Regular expressions used to parse portions of listing line) {
         // Isolate segment directive and it's segment label
@@ -272,7 +272,7 @@ export class SourceMap {
         let reg3 = /^([A-F0-9]{6})(?:r\s\d\s*)((?:[0-9A-Frx]{2}\s){0,4})(?:\s*)([A-z0-9@]+[:]+)?(?:\s*)([^;]*)/;
 
         this.modules.forEach(module => {
-            let file = dir + module.name + ".lst";
+            let file = path.join(dir, module.name + ".lst");
             let m = fs.readFileSync(file);
             let lines = new TextDecoder().decode(m).split(/\r?\n/);
             let sline = 0;

--- a/wp/.vscode/launch.json
+++ b/wp/.vscode/launch.json
@@ -5,24 +5,24 @@
 			"type": "65816",
 			"request": "launch",
 			"name": "Debug file",
-            "program": "${file}",
-            "stopOnEntry": true,
+			"program": "${file}",
+			"stopOnEntry": true,
 		},
 		{
 			"type": "65816",
 			"request": "launch",
 			"name": "Lauch with args",
-            "program": "${file}",
-            "args": [
-                {
-                    "acia": "0x01ff20",
-                    "via": "0x01ff10",
-                    "sbin": "sforth.bin",
-                    "fbin": "block.bin"
-                }
-            ],
-            "stopOnEntry": true,
-            "cwd": "${cwd}"
+			"program": "${file}",
+			"args": [
+				{
+					"acia": "0x01ff20",
+					"via": "0x01ff10",
+					"sbin": "sforth.bin",
+					"fbin": "block.bin"
+				}
+			],
+			"stopOnEntry": true,
+			"cwd": "${cwd}"
 		},
 		{
 			"type": "65816",


### PR DESCRIPTION
Hi @tmr4,

Thanks for publishing the source for the extension. I just had a basic play with it and it seems promising. I added it to my list of things to implement on my build. I'm using ACME, though, so I will have to consider switching assemblers (or maybe adding support for it here?).

I ran into an issue while trying it, as it seems you're working on Windows and had `\` hard-coded as a path separator. I updated the code to use the `path.join()` method, which is platform-agnostic.

This pull request also includes the following cosmetic fixes:
- Add a `.gitignore` file to ignore npm outputs directories
- Formatted `wp/.vscode/launch.json` to be more readable

I would also recommend you update your VScode configuration to enable the following settings, as I noticed some files had trailing whitespaces and no final new line.

```json
{ 
    "files.trimTrailingWhitespace": true,
    "files.insertFinalNewline": true,
    "files.trimFinalNewlines": true,
}
```

Hope that this is useful!